### PR TITLE
Enhanced readability with colors

### DIFF
--- a/printer/colors_definition.go
+++ b/printer/colors_definition.go
@@ -6,19 +6,12 @@ var (
 	// Preset of colors for background
 	// Please use them when you just need random colors
 	colorsForDarkBackground = []color.Color{
-		color.Cyan,
-		color.Green,
-		color.Magenta,
 		color.White,
-		color.Yellow,
+		color.Cyan,
 	}
 
 	colorsForLightBackground = []color.Color{
-		color.Cyan,
-		color.Green,
-		color.Magenta,
 		color.Black,
-		color.Yellow,
 		color.Blue,
 	}
 
@@ -26,16 +19,16 @@ var (
 	// e.g. Json, Yaml, kubectl-describe format etc.
 
 	// colors which look good in dark-backgrounded environment
-	KeyColorForDark    = color.White
-	StringColorForDark = color.Cyan
+	KeyColorForDark    = color.Cyan
+	StringColorForDark = color.White
 	BoolColorForDark   = color.Green
 	NumberColorForDark = color.Magenta
 	NullColorForDark   = color.Yellow
 	HeaderColorForDark = color.White // for plain table
 
 	// colors which look good in light-backgrounded environment
-	KeyColorForLight    = color.Black
-	StringColorForLight = color.Blue
+	KeyColorForLight    = color.Blue
+	StringColorForLight = color.Black
 	BoolColorForLight   = color.Green
 	NumberColorForLight = color.Magenta
 	NullColorForLight   = color.Yellow

--- a/printer/format.go
+++ b/printer/format.go
@@ -18,7 +18,7 @@ func getColorByKeyIndent(indent int, basicIndentWidth int, dark bool) color.Colo
 	switch indent / basicIndentWidth % 2 {
 	case 1:
 		if dark {
-			return color.White
+			return color.Cyan
 		}
 		return color.Black
 	default:

--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -103,7 +103,7 @@ func (kp *KubectlOutputColoredPrinter) Print(r io.Reader, w io.Writer) {
 	}
 
 	if kp.SubcommandInfo.Help {
-		printer = &SingleColoredPrinter{Color: color.Yellow}
+		printer = &SingleColoredPrinter{Color: color.White}
 	}
 
 	printer.Print(r, w)


### PR DESCRIPTION
color the status in yellow or red, depending on the severity

   no color is used for normal status, like Running. Green is not used in
   order to avoid the confusion with red color for color blind users.

   yellow is used for warnings and transional status, like Pending - very
   useful to differentiate Pending and Running.

   red is used for failed, error, ... status


   because strings contain the most information, and white is the most
   readable color, strings are changed to white color.

   table output is changed to two alternating colors, to enhance the
   readability of the columns without using too many colors

   key indent color alternates between yellow and cyan to enhance the indent
   readability and differentiate the key from the content

   while it would be great to enhance the readability of the help page,
   coloring everything in yellow doesn't seem to help for that purpose. As for
   strings, white is more readable and seems more suited for this complex
   content

## Related issue (if exists)