### PR TITLE
Update goreleaser GH action version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           go-version: 1.16.x
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
Updates the homebrew formula to remove bottle.

fixes #81 via https://github.com/goreleaser/goreleaser/pull/2591

## WHAT
Homebrew installs and updates show the following error

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the dty1er/tap tap (not Homebrew/brew or Homebrew/core):
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/dty1er/homebrew-tap/Formula/kubecolor.rb:9
```

## WHY
Homebrew updated to remove bottle support

## Related issue (if exists)
#81 
