### PR TITLE
remove ctx and ns subcommand from colorization

### DIFF
--- a/command/subcommand.go
+++ b/command/subcommand.go
@@ -54,6 +54,8 @@ func isColoringSupported(sc kubectl.Subcommand) bool {
 		kubectl.Plugin,
 		kubectl.Wait,
 		kubectl.Run,
+		kubectl.Ctx,
+		kubectl.Ns,
 	}
 
 	for _, u := range unsupported {

--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -70,6 +70,8 @@ const (
 	Plugin
 	Version
 	Options
+	Ctx
+	Ns
 )
 
 var strToSubcommand = map[string]Subcommand{
@@ -115,6 +117,8 @@ var strToSubcommand = map[string]Subcommand{
 	"plugin":        Plugin,
 	"version":       Version,
 	"options":       Options,
+	"ctx":           Ctx,
+	"ns":            Ns,
 }
 
 func InspectSubcommand(command string) (Subcommand, bool) {


### PR DESCRIPTION
## WHAT
Remove colorization from `kubecolor ctx` and `kubecolor ns`

## WHY
`kubectl ctx` and `kubectl ns` returns a list colored white with one selected item in yellow.
The `ctx` and `ns` commands called from `kubecolor` return everything in yellow, making it impossible to find which context or namespace is currently used as default.

## Related issue (if exists)
https://github.com/hidetatz/kubecolor/issues/85