### PR TITLE
fix(completions): Do not colorize output for bash completions

### DIFF
--- a/command/subcommand.go
+++ b/command/subcommand.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"os"
+	"strings"
 
 	"github.com/hidetatz/kubecolor/kubectl"
 	"github.com/mattn/go-isatty"
@@ -24,6 +25,15 @@ func ResolveSubcommand(args []string, config *KubecolorConfig) (bool, *kubectl.S
 	// if subcommand is not found (e.g. kubecolor --help or just "kubecolor"),
 	// it is treated as help because kubectl shows help for such input
 	if !subcommandFound {
+		// if there is an argument starting with __,
+		// the subcommand is probably an internal subcommand (like __completeNoDesc)
+		// and should probably not be colorized
+		for i := range args {
+			if strings.HasPrefix(args[i], "__") {
+				return false, subcommandInfo
+			}
+		}
+
 		subcommandInfo.Help = true
 		return true, subcommandInfo
 	}


### PR DESCRIPTION
## WHAT

The bash completion for kubectl use internal subcommands.
Internal subcommands start with `__`.
These should never be colorized.

## WHY

Because it fixes an existing problem with the bash completions.

## Related issue (if exists)

Relates to: #78
Fixes at least my problem: https://github.com/hidetatz/kubecolor/issues/78#issuecomment-986071841
