### PR TITLE
Support recursive without argument

### DIFF
--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -187,7 +187,7 @@ func CollectCommandlineOptions(args []string, info *SubcommandInfo) {
 			info.NoHeader = true
 		} else if args[i] == "-w" || args[i] == "--watch" {
 			info.Watch = true
-		} else if args[i] == "--recursive=true" {
+		} else if args[i] == "--recursive=true" || args[i] == "--recursive" {
 			info.Recursive = true
 		} else if args[i] == "-h" || args[i] == "--help" {
 			info.Help = true

--- a/kubectl/subcommand_test.go
+++ b/kubectl/subcommand_test.go
@@ -51,8 +51,7 @@ func TestInspectSubcommandInfo(t *testing.T) {
 
 		{"explain pod", &SubcommandInfo{Subcommand: Explain}, true},
 		{"explain pod --recursive=true", &SubcommandInfo{Subcommand: Explain, Recursive: true}, true},
-		// "--recursive true" is not acceptable by kubectl explain
-		{"explain pod --recursive true", &SubcommandInfo{Subcommand: Explain}, true},
+		{"explain pod --recursive", &SubcommandInfo{Subcommand: Explain, Recursive: true}, true},
 
 		{"version", &SubcommandInfo{Subcommand: Version}, true},
 		{"version --client", &SubcommandInfo{Subcommand: Version}, true},


### PR DESCRIPTION
## WHAT

This PR is adding the support for the `--recursive` command line argument that doesn't specify the boolean value (`--recursive=true`).

## WHY

Some people don't specify the boolean value and because `kubectl` doesn't require it. With the current implementation, the `explain` output is completely broken if the boolean value is not specified.

## Related issue (if exists)

N/A