### PR TITLE
Allow forcing colors via KUBECOLOR_FORCE_COLORS env var

### DIFF
--- a/command/config.go
+++ b/command/config.go
@@ -18,6 +18,8 @@ func ResolveConfig(args []string) ([]string, *KubecolorConfig) {
 
 	darkBackground := !lightBackgroundFlagFound
 
+	colorsForcedViaEnv := os.Getenv("KUBECOLOR_FORCE_COLORS") == "true"
+
 	kubectlCmd := "kubectl"
 	if kc := os.Getenv("KUBECTL_COMMAND"); kc != "" {
 		kubectlCmd = kc
@@ -26,7 +28,7 @@ func ResolveConfig(args []string) ([]string, *KubecolorConfig) {
 	return args, &KubecolorConfig{
 		Plain:                plainFlagFound,
 		DarkBackground:       darkBackground,
-		ForceColor:           forceColorFlagFound,
+		ForceColor:           forceColorFlagFound || colorsForcedViaEnv,
 		ShowKubecolorVersion: kubecolorVersionFlagFound,
 		KubectlCmd:           kubectlCmd,
 	}


### PR DESCRIPTION
This allows colors to be displayed when kubecolor is invoked via the 'watch' command. All you need is the following alias:
```bash
  alias watch='KUBECOLOR_FORCE_COLORS=true watch --color '
```